### PR TITLE
Note that this fork is deprecated in favour of dalet-oss/vfs-azure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# This fork is deprecated
+
+The deltas on this fork have been moved to https://github.com/dalet-oss/vfs-azure/, and ongoing development will
+continue there.
+
+
 # vfs-azure
 Azure provider for Apache Commons VFS - http://commons.apache.org/proper/commons-vfs/
 


### PR DESCRIPTION
Add a note for any external consumers, giving a helpful hint on where to look for updates after this point.